### PR TITLE
Fix argument escaping on Windows (issue #1)

### DIFF
--- a/elvee.c
+++ b/elvee.c
@@ -483,6 +483,9 @@ void timestamp()
 
 // Adapted from https://docs.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
 // See issue #1
+// If quoting is needed then a newly allocated string is returned with with
+// "arg" content copied, quoted and escaped. If quoting is unnecessary then
+// "arg" is returned as-is.
 
 char *argv_quote(char *arg)
 {

--- a/elvee.c
+++ b/elvee.c
@@ -313,7 +313,7 @@ int main(int argc, char **argv)
             if (qargv == NULL) {
                 qargv = calloc(argc, sizeof(char*));
             }
-            qargv[i] = qarg;
+            qargv[i] = argv[i];
         }
         argv[i] = qarg;
     }
@@ -321,10 +321,14 @@ int main(int argc, char **argv)
     intptr_t result = _spawnv(_P_WAIT, spawn_path, argv);
 
     // Free any quoted arguments, including their tracking.
+    // Restore argv to its original state.
 
     if (qargv) {
         for (int i = 0; i < argc; i++) {
-            free(qargv[i]);
+            if (qargv[i]) {
+                free(argv[i]);
+                argv[i] = qargv[i];
+            }
         }
         free(qargv);
     }

--- a/elvee.c
+++ b/elvee.c
@@ -305,7 +305,7 @@ int main(int argc, char **argv)
 #ifdef WINDOWS
 
     for (int i = 0; i < argc; i++) {
-      argv[i] = argv_quote(argv[i]);
+        argv[i] = argv_quote(argv[i]);
     }
     intptr_t result = _spawnv(_P_WAIT, spawn_path, argv);
     if (result == -1) {
@@ -463,7 +463,8 @@ void timestamp()
 // Adapted from https://docs.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
 // See issue #1
 // The returned pointer is a new allocation, but leaking it is fine.
-char *argv_quote(char *arg) {
+char *argv_quote(char *arg)
+{
     int needs_quote = 0;
     int escape_count = 0;
     int arglen = 0;

--- a/elvee.c
+++ b/elvee.c
@@ -483,9 +483,9 @@ void timestamp()
 
 // Adapted from https://docs.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
 // See issue #1
-// If quoting is needed then a newly allocated string is returned with with
-// "arg" content copied, quoted and escaped. If quoting is unnecessary then
-// "arg" is returned as-is.
+// If quoting is needed then a newly allocated string is returned with "arg"
+// content copied, quoted and escaped. If quoting is unnecessary then "arg" is
+// returned as-is.
 
 char *argv_quote(char *arg)
 {

--- a/elvee.c
+++ b/elvee.c
@@ -320,7 +320,7 @@ int main(int argc, char **argv)
 
     intptr_t result = _spawnv(_P_WAIT, spawn_path, argv);
 
-    // Free any quote arguments, including their tracking.
+    // Free any quoted arguments, including their tracking.
 
     if (qargv) {
         for (int i = 0; i < argc; i++) {

--- a/elvee.c
+++ b/elvee.c
@@ -304,10 +304,17 @@ int main(int argc, char **argv)
 
 #ifdef WINDOWS
 
+    char **qargv = malloc(sizeof(char*) * argc);
     for (int i = 0; i < argc; i++) {
-        argv[i] = argv_quote(argv[i]);
+        char *qarg = argv_quote(argv[i]);
+        qargv[i] = qarg == argv[i] ? NULL : qarg;
+        argv[i] = qarg;
     }
     intptr_t result = _spawnv(_P_WAIT, spawn_path, argv);
+    for (int i = 0; i < argc; i++) {
+        free(qargv[i]);
+    }
+    free(qargv);
     if (result == -1) {
         printf_app_error("Error launching: %s\nReason: %s", spawn_path, strerror(errno));
         return 1;
@@ -462,7 +469,7 @@ void timestamp()
 
 // Adapted from https://docs.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
 // See issue #1
-// The returned pointer is a new allocation, but leaking it is fine.
+
 char *argv_quote(char *arg)
 {
     int needs_quote = 0;


### PR DESCRIPTION
Simple fix.

This was quite fun.